### PR TITLE
Update_Albedo.csv

### DIFF
--- a/albedo.csv
+++ b/albedo.csv
@@ -1,3 +1,3 @@
 site,location,land cover type,day of year,time of day,value,reference,remarks
 example,London,built-up surface,10,13:00,0.1,[Kotthaus et al (2014)](https://www.sciencedirect.com/science/article/pii/S0924271614001233#),a sample concrete slab
-Crop field,UK,Cropland,25,13:00,0.2,Tom Markvart; Luis CastaŁżer (2003). Practical Handbook of Photovoltaics: Fundamentals and Applications. Elsevier. ISBN 978-1-85617-390-2., a short growing crop
+US-SRG, Santa Rita Grassland, Grassland, 27, 12:00, 0.24, [Moore (1976)](https://rmets.onlinelibrary.wiley.com/doi/epdf/10.1002/qj.49710243416), summer value of grassland 


### PR DESCRIPTION
Information of albedo for Santa Rita Grassland is updated into the file. Article is chosen based on the land cover type which are similar in Santa Rita Grassland and the site in the article.